### PR TITLE
Update TwigExtension.php - Fixing nicetime when post time equals current date

### DIFF
--- a/system/src/Grav/Common/Twig/TwigExtension.php
+++ b/system/src/Grav/Common/Twig/TwigExtension.php
@@ -445,6 +445,9 @@ class TwigExtension extends \Twig_Extension
             $difference = $now - $unix_date;
             $tense      = $this->grav['language']->translate('NICETIME.AGO', null, true);
 
+        } else if ($now == $unix_date) {
+            $tense      = $this->grav['language']->translate('NICETIME.JUST_NOW', null, false);
+            
         } else {
             $difference = $unix_date - $now;
             $tense      = $this->grav['language']->translate('NICETIME.FROM_NOW', null, true);
@@ -469,8 +472,13 @@ class TwigExtension extends \Twig_Extension
         }
 
         $periods[$j] = $this->grav['language']->translate($periods[$j], null, true);
-
-        return "$difference $periods[$j] {$tense}";
+        
+        if ($now == $unix_date) {
+            return "{$tense}";
+        }
+        else {
+            return "$difference $periods[$j] {$tense}";
+        }
     }
 
     /**


### PR DESCRIPTION
Check if date matches, which means the post / comment was posted just now. 

Will return proper value to whatever function uses it.
The file /system/languages/en.yaml and basically all language files need to include the JUST_NOW text value which should be "just now", of course correctly translated in each language.

This fix has been created in order to fix the "0 seconds from now" message as it sounds weird.